### PR TITLE
Fix null default parameter bug

### DIFF
--- a/HoneydewCore/Extractors/Metrics/SemanticMetrics/MethodInfoMetric.cs
+++ b/HoneydewCore/Extractors/Metrics/SemanticMetrics/MethodInfoMetric.cs
@@ -260,7 +260,7 @@ namespace HoneydewCore.Extractors.Metrics.SemanticMetrics
                 string defaultValue = null;
                 if (parameter.HasExplicitDefaultValue)
                 {
-                    defaultValue = parameter.ExplicitDefaultValue!.ToString();
+                    defaultValue = parameter.ExplicitDefaultValue?.ToString();
                 }
 
                 parameterTypes.Add(new ParameterModel

--- a/HoneydewCoreTest/Extractors/Metrics/SyntacticMetrics/MethodInfoMetricTests.cs
+++ b/HoneydewCoreTest/Extractors/Metrics/SyntacticMetrics/MethodInfoMetricTests.cs
@@ -926,5 +926,22 @@ namespace HoneydewCoreTest.Extractors.Metrics.SyntacticMetrics
                 Assert.Equal("", constructorModel.Modifier);
             }
         }
+
+        [Fact]
+        public void Extract_ShouldExtractNullDefaultValue()
+        {
+            const string fileContent = @"using System;
+                                     using HoneydewCore.Extractors;
+                                     namespace TopLevel
+                                     {
+                                            public class Bar
+                                            {
+                                                int MethodWithNullableDefault(string? p = null) {return 2;}
+                                            }                                  
+                                     }";
+
+            var classModels = _factExtractor.Extract(fileContent);
+            Assert.Equal("null", classModels[0].Methods[0].ParameterTypes[0].DefaultValue);
+        }
     }
 }


### PR DESCRIPTION
Previously, it would have failed to parse a method with a null default parameter value.